### PR TITLE
add vault path prefix

### DIFF
--- a/main.go
+++ b/main.go
@@ -63,6 +63,7 @@ this repository has new commits, Wadsworth will automatically reconfigure.`,
 				cli.DurationFlag{Name: "check-interval", EnvVar: "CHECK_INTERVAL", Value: time.Second * 10},
 				cli.StringFlag{Name: "vault-addr", EnvVar: "VAULT_ADDR"},
 				cli.StringFlag{Name: "vault-token", EnvVar: "VAULT_TOKEN"},
+				cli.StringFlag{Name: "vault-path", EnvVar: "VAULT_PATH"},
 			},
 			Action: func(c *cli.Context) (err error) {
 				if !c.Args().Present() {
@@ -79,6 +80,7 @@ this repository has new commits, Wadsworth will automatically reconfigure.`,
 					CheckInterval: c.Duration("check-interval"),
 					VaultAddress:  c.String("vault-addr"),
 					VaultToken:    c.String("vault-token"),
+					VaultPath:     c.String("vault-path"),
 				})
 				if err != nil {
 					return errors.Wrap(err, "failed to initialise")

--- a/service/secrets.go
+++ b/service/secrets.go
@@ -1,6 +1,10 @@
 package service
 
-import "github.com/pkg/errors"
+import (
+	"path/filepath"
+
+	"github.com/pkg/errors"
+)
 
 func (app *App) getSecretsForTarget(name string) (env map[string]string, err error) {
 	if app.vault != nil {
@@ -10,7 +14,7 @@ func (app *App) getSecretsForTarget(name string) (env map[string]string, err err
 }
 
 func (app *App) secretsFromVault(name string) (env map[string]string, err error) {
-	path := "/secret/" + name
+	path := filepath.Join("/secret", app.config.VaultPath, name)
 	secret, err := app.vault.Logical().Read(path)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to read secret")

--- a/service/service.go
+++ b/service/service.go
@@ -36,6 +36,7 @@ type Config struct {
 	CheckInterval time.Duration
 	VaultAddress  string
 	VaultToken    string
+	VaultPath     string
 }
 
 // Initialise prepares an instance of the app to run


### PR DESCRIPTION
This permits the use of a prefix for specifying "directories" for Vault secrets for the running instance of Wadsworth. This facilitates more fine grained control of secret access on different Wadsworth nodes.